### PR TITLE
Refine snappyHexMesh options to accelerate meshing.

### DIFF
--- a/mesh_study.sh
+++ b/mesh_study.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 declare -a mesh_size
-mesh_size=( 50 100 200 300 400 )
+mesh_size=( 100 200 400 )
 	
 for i in "${mesh_size[@]}"
 do

--- a/test_cases/cylinder2D_base/system/snappyHexMeshDict
+++ b/test_cases/cylinder2D_base/system/snappyHexMeshDict
@@ -28,12 +28,12 @@ geometry
         radius  0.05;
     }
 
-    /*refBox
+    refBox
     {
         type searchableBox;
-        min (-0.03 -0.015 -0.12);
-        max ( 1.27  0.425  0.12);
-    }*/
+        min (  -1 -1 -1);
+        max ( 0.6  1  1);
+    }
 }
 
 
@@ -52,7 +52,7 @@ castellatedMeshControls
     {
         cylinder
         {
-            level (4 4);
+            level (1 1);
             patchInfo
             {
                 type        patch;
@@ -61,11 +61,11 @@ castellatedMeshControls
     };
     refinementRegions
     {
-        /*refBox
+        refBox
         {
             mode        inside;
-            levels      ((2 2));
-        }*/
+            levels      ((1 1));
+        }
     };
     locationInMesh (1.02 0.15 0.000000001);
 }
@@ -75,8 +75,8 @@ snapControls
 {
     nSmoothPatch    3;
     tolerance       2.0;
-    nSolveIter      100;
-    nRelaxIter      5;
+    nSolveIter      50;
+    nRelaxIter      3;
 }
 
 
@@ -91,7 +91,7 @@ addLayersControls
     {
         cylinder
         {
-            nSurfaceLayers 6;
+            nSurfaceLayers 8;
         }
     }
 


### PR DESCRIPTION
Hi Darshan,
I changed the *snappyHexMesh* options slightly. I think that 100, 200, and 400 cells should be fine for the mesh dependency study. The memory requirements with 400 cells are actually rather small, but the meshing process takes a bit longer (a couple of minutes)
Best, Andre